### PR TITLE
掃除タスクのCRUD機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ erDiagram
 ### API エンドポイント
 | メソッド | エンドポイント | 説明 |
 | :--- | :--- | :--- |
-| GET | `/tasks` | 掃除タスク一覧を取得 |
-| POST | `/tasks` | 新しい掃除タスクを追加 |
-| PUT | `/tasks/{taskId}` | 掃除タスクを編集 |
-| DELETE | `/tasks/{taskId}` | 掃除タスクを削除 |
-| POST | `/tasks/{taskId}/complete` | 掃除完了の記録と次回予定日の更新 |
+| GET | `/api/tasks` | 掃除タスク一覧を取得 |
+| POST | `/api/tasks` | 新しい掃除タスクを追加 |
+| PUT | `/api/tasks/{taskId}` | 掃除タスクを編集 |
+| DELETE | `/api/tasks/{taskId}` | 掃除タスクを削除 |
+| POST | `/api/tasks/{taskId}/complete` | 掃除完了の記録と次回予定日の更新 |

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/backend/src/main/java/com/example/cleaning_notification_app/controller/TaskController.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/controller/TaskController.java
@@ -1,0 +1,52 @@
+package com.example.cleaning_notification_app.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.cleaning_notification_app.request.TaskRequest;
+import com.example.cleaning_notification_app.response.TaskResponse;
+import com.example.cleaning_notification_app.service.TaskService;
+
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+
+@RestController
+@RequestMapping("/api/tasks")
+@AllArgsConstructor
+public class TaskController {
+    private final TaskService taskService;
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<TaskResponse> getAllTasks() {
+        return taskService.getAllTasks();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TaskResponse createTask(@RequestBody @Valid TaskRequest taskRequest) {
+        return taskService.createTask(taskRequest);
+    }
+
+    @PutMapping("/{taskId}")
+    @ResponseStatus(HttpStatus.OK)
+    public TaskResponse updateTask(@RequestBody @Valid TaskRequest taskRequest, @PathVariable Long taskId) {
+        return taskService.updateTask(taskRequest, taskId);
+    }
+
+    @DeleteMapping("/{taskId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteTask(@PathVariable Long taskId) {
+        taskService.deleteTask(taskId);
+    }
+}

--- a/backend/src/main/java/com/example/cleaning_notification_app/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.example.cleaning_notification_app.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.example.cleaning_notification_app.response.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // @Validによるバリデーションエラーをキャッチする
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        // 発生した全てのエラーをループで回してMapに格納する
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        return new ErrorResponse("入力内容に不備があります", errors);
+    }
+}

--- a/backend/src/main/java/com/example/cleaning_notification_app/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -21,8 +20,8 @@ public class GlobalExceptionHandler {
         Map<String, String> errors = new HashMap<>();
 
         // 発生した全てのエラーをループで回してMapに格納する
-        ex.getBindingResult().getAllErrors().forEach((error) -> {
-            String fieldName = ((FieldError) error).getField();
+        ex.getBindingResult().getFieldErrors().forEach((error) -> {
+            String fieldName = error.getField();
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);
         });

--- a/backend/src/main/java/com/example/cleaning_notification_app/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -27,5 +28,11 @@ public class GlobalExceptionHandler {
         });
 
         return new ErrorResponse("入力内容に不備があります", errors);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        ErrorResponse error = new ErrorResponse("リソースが見つかりません", ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
     }
 }

--- a/backend/src/main/java/com/example/cleaning_notification_app/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.cleaning_notification_app.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/example/cleaning_notification_app/request/TaskRequest.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/request/TaskRequest.java
@@ -1,0 +1,27 @@
+package com.example.cleaning_notification_app.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class TaskRequest {
+    @NotEmpty(message = "場所は必須です")
+    private String place;
+
+    @NotEmpty(message = "対象は必須です")
+    private String target;
+
+    @NotNull(message = "頻度は必須です")
+    @Min(value = 1, message = "頻度は1日以上で指定してください")
+    private Integer intervalDays;
+
+    private String method;
+}

--- a/backend/src/main/java/com/example/cleaning_notification_app/request/TaskRequest.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/request/TaskRequest.java
@@ -1,8 +1,9 @@
 package com.example.cleaning_notification_app.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +14,12 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TaskRequest {
-    @NotEmpty(message = "場所は必須です")
+    @NotBlank(message = "場所は必須です")
+    @Size(max = 100, message = "場所は100字以内で入力してください")
     private String place;
 
-    @NotEmpty(message = "対象は必須です")
+    @NotBlank(message = "対象は必須です")
+    @Size(max = 100, message = "対象は100字以内で入力してください")
     private String target;
 
     @NotNull(message = "頻度は必須です")

--- a/backend/src/main/java/com/example/cleaning_notification_app/response/ErrorResponse.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/response/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.example.cleaning_notification_app.response;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String message;
+    private Map<String , String> errors; // key: フィールド名、value: エラーメッセージ
+}

--- a/backend/src/main/java/com/example/cleaning_notification_app/response/ErrorResponse.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/response/ErrorResponse.java
@@ -9,5 +9,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ErrorResponse {
     private String message;
-    private Map<String , String> errors; // key: フィールド名、value: エラーメッセージ
+    private Map<String, String> errors; // key: フィールド名、value: エラーメッセージ
 }

--- a/backend/src/main/java/com/example/cleaning_notification_app/response/ErrorResponse.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/response/ErrorResponse.java
@@ -9,5 +9,16 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ErrorResponse {
     private String message;
+    private String details;
     private Map<String, String> errors; // key: フィールド名、value: エラーメッセージ
+
+    public ErrorResponse(String message, String details) {
+        this.message = message;
+        this.details = details;
+    }
+
+    public ErrorResponse(String message, Map<String, String> errors) {
+        this.message = message;
+        this.errors = errors;
+    }
 }

--- a/backend/src/main/java/com/example/cleaning_notification_app/response/TaskResponse.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/response/TaskResponse.java
@@ -1,0 +1,19 @@
+package com.example.cleaning_notification_app.response;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class TaskResponse {
+    private Long id;
+    private String place;
+    private String target;
+    private Integer intervalDays;
+    private String method;
+    private LocalDate nextDueDate;
+}

--- a/backend/src/main/java/com/example/cleaning_notification_app/response/TaskResponse.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/response/TaskResponse.java
@@ -4,11 +4,9 @@ import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @AllArgsConstructor
 @Getter
-@Setter
 public class TaskResponse {
     private Long id;
     private String place;

--- a/backend/src/main/java/com/example/cleaning_notification_app/service/TaskService.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/service/TaskService.java
@@ -1,0 +1,13 @@
+package com.example.cleaning_notification_app.service;
+
+import java.util.List;
+
+import com.example.cleaning_notification_app.request.TaskRequest;
+import com.example.cleaning_notification_app.response.TaskResponse;
+
+public interface TaskService {
+    List<TaskResponse> getAllTasks();
+    TaskResponse createTask(TaskRequest taskRequest);
+    TaskResponse updateTask(TaskRequest taskRequest, Long id);
+    void deleteTask(Long id);
+}

--- a/backend/src/main/java/com/example/cleaning_notification_app/service/TaskService.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/service/TaskService.java
@@ -8,6 +8,6 @@ import com.example.cleaning_notification_app.response.TaskResponse;
 public interface TaskService {
     List<TaskResponse> getAllTasks();
     TaskResponse createTask(TaskRequest taskRequest);
-    TaskResponse updateTask(TaskRequest taskRequest, Long id);
-    void deleteTask(Long id);
+    TaskResponse updateTask(TaskRequest taskRequest, Long taskId);
+    void deleteTask(Long taskId);
 }

--- a/backend/src/main/java/com/example/cleaning_notification_app/service/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/service/TaskServiceImpl.java
@@ -1,0 +1,81 @@
+package com.example.cleaning_notification_app.service;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.example.cleaning_notification_app.entity.Task;
+import com.example.cleaning_notification_app.repository.TaskRepository;
+import com.example.cleaning_notification_app.request.TaskRequest;
+import com.example.cleaning_notification_app.response.TaskResponse;
+
+import lombok.AllArgsConstructor;
+
+@Service
+@AllArgsConstructor
+public class TaskServiceImpl implements TaskService {
+    private final TaskRepository taskRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TaskResponse> getAllTasks() {
+        return taskRepository.findAll().stream().map(this::convertToTaskResponse).toList();
+    }
+
+    @Override
+    @Transactional
+    public TaskResponse createTask(TaskRequest taskRequest) {
+        Task task = new Task();
+        task.setPlace(taskRequest.getPlace());
+        task.setTarget(taskRequest.getTarget());
+        task.setIntervalDays(taskRequest.getIntervalDays());
+        task.setMethod(taskRequest.getMethod());
+
+        // とりあえず今日の日付をセットしておく→ロジックを作成した後は置き換える
+        task.setNextDueDate(java.time.LocalDate.now());
+
+        Task savedTask = taskRepository.save(task);
+        return convertToTaskResponse(savedTask);
+    }
+
+    @Override
+    @Transactional
+    public TaskResponse updateTask(TaskRequest taskRequest, Long id) {
+        Task task = taskRepository.findById(id)
+                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "掃除タスクが見つかりませんでした"));
+
+        task.setPlace(taskRequest.getPlace());
+        task.setTarget(taskRequest.getTarget());
+        task.setIntervalDays(taskRequest.getIntervalDays());
+        task.setMethod(taskRequest.getMethod());
+
+        // とりあえず今日の日付をセットしておく→ロジックを作成した後は置き換える
+        task.setNextDueDate(java.time.LocalDate.now());
+
+        Task savedTask = taskRepository.save(task);
+        return convertToTaskResponse(savedTask);
+    }
+
+    @Override
+    @Transactional
+    public void deleteTask(Long id) {
+        Task task = taskRepository.findById(id)
+                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "掃除タスクが見つかりませんでした"));
+
+        taskRepository.delete(task);
+    }
+
+    private TaskResponse convertToTaskResponse(Task task) {
+        return new TaskResponse(
+            task.getId(),
+            task.getPlace(),
+            task.getTarget(),
+            task.getIntervalDays(),
+            task.getMethod(),
+            task.getNextDueDate()
+        );
+    }
+}

--- a/backend/src/main/java/com/example/cleaning_notification_app/service/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/service/TaskServiceImpl.java
@@ -43,8 +43,8 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     @Transactional
-    public TaskResponse updateTask(TaskRequest taskRequest, Long id) {
-        Task task = taskRepository.findById(id)
+    public TaskResponse updateTask(TaskRequest taskRequest, Long taskId) {
+        Task task = taskRepository.findById(taskId)
                         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "掃除タスクが見つかりませんでした"));
 
         task.setPlace(taskRequest.getPlace());
@@ -61,8 +61,8 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     @Transactional
-    public void deleteTask(Long id) {
-        Task task = taskRepository.findById(id)
+    public void deleteTask(Long taskId) {
+        Task task = taskRepository.findById(taskId)
                         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "掃除タスクが見つかりませんでした"));
 
         taskRepository.delete(task);

--- a/backend/src/main/java/com/example/cleaning_notification_app/service/TaskServiceImpl.java
+++ b/backend/src/main/java/com/example/cleaning_notification_app/service/TaskServiceImpl.java
@@ -2,12 +2,11 @@ package com.example.cleaning_notification_app.service;
 
 import java.util.List;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import com.example.cleaning_notification_app.entity.Task;
+import com.example.cleaning_notification_app.exception.ResourceNotFoundException;
 import com.example.cleaning_notification_app.repository.TaskRepository;
 import com.example.cleaning_notification_app.request.TaskRequest;
 import com.example.cleaning_notification_app.response.TaskResponse;
@@ -45,7 +44,7 @@ public class TaskServiceImpl implements TaskService {
     @Transactional
     public TaskResponse updateTask(TaskRequest taskRequest, Long taskId) {
         Task task = taskRepository.findById(taskId)
-                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "掃除タスクが見つかりませんでした"));
+                        .orElseThrow(() -> new ResourceNotFoundException("掃除タスクが見つかりませんでした。ID: " + taskId));
 
         task.setPlace(taskRequest.getPlace());
         task.setTarget(taskRequest.getTarget());
@@ -63,7 +62,7 @@ public class TaskServiceImpl implements TaskService {
     @Transactional
     public void deleteTask(Long taskId) {
         Task task = taskRepository.findById(taskId)
-                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "掃除タスクが見つかりませんでした"));
+                        .orElseThrow(() -> new ResourceNotFoundException("掃除タスクが見つかりませんでした。ID: " + taskId));
 
         taskRepository.delete(task);
     }

--- a/backend/src/test/java/com/example/cleaning_notification_app/controller/TaskControllerTest.java
+++ b/backend/src/test/java/com/example/cleaning_notification_app/controller/TaskControllerTest.java
@@ -1,0 +1,46 @@
+package com.example.cleaning_notification_app.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.cleaning_notification_app.request.TaskRequest;
+import com.example.cleaning_notification_app.service.TaskServiceImpl;
+
+import tools.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(TaskController.class)
+public class TaskControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private TaskServiceImpl taskServiceImpl;
+
+    @Test
+    @DisplayName("バリテーションエラー：不正な入力値の場合、404エラーが返ること")
+    void createTask_ValidationError_Returns404() throws Exception {
+        TaskRequest invalidRequest = new TaskRequest("", "浴槽", -1, "洗剤で洗う");
+
+        String requestBody = objectMapper.writeValueAsString(invalidRequest);
+
+        mockMvc.perform(post("/api/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+                .andExpect(status().isBadRequest()) // HTTPステータスが400であることを検証
+                .andExpect(jsonPath("$.message").value("入力内容に不備があります")) // エラーメッセージの検証
+                .andExpect(jsonPath("$.errors.place").exists()) // place のエラー詳細が存在するか検証
+                .andExpect(jsonPath("$.errors.intervalDays").exists()); // intervalDays のエラー詳細が存在するか検証
+    }
+}

--- a/backend/src/test/java/com/example/cleaning_notification_app/controller/TaskControllerTest.java
+++ b/backend/src/test/java/com/example/cleaning_notification_app/controller/TaskControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.cleaning_notification_app.request.TaskRequest;
-import com.example.cleaning_notification_app.service.TaskServiceImpl;
+import com.example.cleaning_notification_app.service.TaskService;
 
 import tools.jackson.databind.ObjectMapper;
 
@@ -26,10 +26,10 @@ public class TaskControllerTest {
     private ObjectMapper objectMapper;
 
     @MockitoBean
-    private TaskServiceImpl taskServiceImpl;
+    private TaskService taskService;
 
     @Test
-    @DisplayName("バリテーションエラー：不正な入力値の場合、404エラーが返ること")
+    @DisplayName("バリテーションエラー：不正な入力値の場合、400エラーが返ること")
     void createTask_ValidationError_Returns404() throws Exception {
         TaskRequest invalidRequest = new TaskRequest("", "浴槽", -1, "洗剤で洗う");
 

--- a/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
+++ b/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,32 @@ public class TaskServiceImplTest {
 
     @InjectMocks
     private TaskServiceImpl taskService;
+
+    @Test
+    @DisplayName("タスク一覧を全権取得できること")
+    void getAllTasks_Success() {
+        Task task1 = new Task();
+        task1.setPlace("場所1");
+        task1.setTarget("対象1");
+        task1.setIntervalDays(7);
+        task1.setMethod("方法1");
+        task1.setNextDueDate(LocalDate.now());
+        Task task2 = new Task();
+        task2.setPlace("場所2");
+        task2.setTarget("対象2");
+        task2.setIntervalDays(3);
+        task2.setMethod("方法2");
+        task2.setNextDueDate(LocalDate.now());
+        when(taskRepository.findAll()).thenReturn(List.of(task1, task2));
+
+        List<TaskResponse> responses = taskService.getAllTasks();
+
+        assertAll(
+            () -> assertEquals(2, responses.size()),
+            () -> assertEquals("場所1", responses.get(0).getPlace()),
+            () -> assertEquals("場所2", responses.get(1).getPlace())
+        );
+    }
 
     @Test
     @DisplayName("新しい掃除タスクを正常に保存できること")
@@ -64,5 +92,66 @@ public class TaskServiceImplTest {
 
         // リポジトリのsaveメソッドが本当に1回だけ呼ばれたか確認
         verify(taskRepository, times(1)).save(any(Task.class));
+    }
+
+    @Test
+    @DisplayName("掃除タスクを更新できること")
+    void updateTask_Success() {
+        Long taskId = 1l;
+
+        Task existingTask = new Task();
+        existingTask.setId(taskId);
+        existingTask.setPlace("お風呂");
+        existingTask.setTarget("浴槽");
+        existingTask.setIntervalDays(7);
+        existingTask.setMethod("洗剤で洗う");
+        existingTask.setNextDueDate(LocalDate.now());
+
+        TaskRequest updateRequest = new TaskRequest("キッチン", "換気扇", 30, "重曹で洗う");
+
+        Task updateTask = new Task();
+        updateTask.setId(taskId);
+        updateTask.setPlace("キッチン");
+        updateTask.setTarget("換気扇");
+        updateTask.setIntervalDays(30);
+        updateTask.setMethod("重曹で洗う");
+        updateTask.setNextDueDate(LocalDate.now());
+
+        when(taskRepository.findById(taskId)).thenReturn(Optional.of(existingTask));
+        when(taskRepository.save(any(Task.class))).thenReturn(updateTask);
+
+        TaskResponse response = taskService.updateTask(updateRequest, taskId);
+
+        assertAll("更新レスポンスの検証",
+            () -> assertEquals(taskId, response.getId()),
+            () -> assertEquals("キッチン", response.getPlace()),
+            () -> assertEquals("換気扇", response.getTarget()),
+            () -> assertEquals(30, response.getIntervalDays()),
+            () -> assertEquals("重曹で洗う", response.getMethod())
+        );
+
+        verify(taskRepository, times(1)).findById(taskId);
+        verify(taskRepository, times(1)).save(any(Task.class));
+    }
+
+    @Test
+    @DisplayName("掃除タスクを削除できること")
+    void deleteTask_Success() {
+        Long taskId = 1L;
+
+        Task existingTask = new Task();
+        existingTask.setId(taskId);
+        existingTask.setPlace("お風呂");
+        existingTask.setTarget("浴槽");
+        existingTask.setIntervalDays(7);
+        existingTask.setMethod("洗剤で洗う");
+        existingTask.setNextDueDate(LocalDate.now());
+
+        when(taskRepository.findById(taskId)).thenReturn(Optional.of(existingTask));
+
+        taskService.deleteTask(taskId);
+
+        verify(taskRepository, times(1)).findById(taskId);
+        verify(taskRepository, times(1)).delete(existingTask);
     }
 }

--- a/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
+++ b/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
@@ -35,11 +35,7 @@ public class TaskServiceImplTest {
     @DisplayName("新しい掃除タスクを正常に保存できること")
     void createTask_Success() {
         // テスト用のリクエストデータを作成
-        TaskRequest request = new TaskRequest();
-        request.setPlace("お風呂");
-        request.setTarget("浴槽");
-        request.setIntervalDays(7);
-        request.setMethod("洗剤で洗う");
+        TaskRequest request = new TaskRequest("お風呂", "浴槽", 7, "洗剤で洗う");
 
         // リポジトリが保存した後に返してくる「完成したデータ」を準備
         Task savedTask = new Task();

--- a/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
+++ b/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.example.cleaning_notification_app.service;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.cleaning_notification_app.entity.Task;
+import com.example.cleaning_notification_app.repository.TaskRepository;
+import com.example.cleaning_notification_app.request.TaskRequest;
+import com.example.cleaning_notification_app.response.TaskResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskServiceImplTest {
+    
+    @Mock
+    private TaskRepository taskRepository;
+
+    @InjectMocks
+    private TaskServiceImpl taskService;
+
+    @Test
+    @DisplayName("新しい掃除タスクを正常に保存できること")
+    void createTask_Success() {
+        // テスト用のリクエストデータを作成
+        TaskRequest request = new TaskRequest();
+        request.setPlace("お風呂");
+        request.setTarget("浴槽");
+        request.setIntervalDays(7);
+        request.setMethod("洗剤で洗う");
+
+        // リポジトリが保存した後に返してくる「完成したデータ」を準備
+        Task savedTask = new Task();
+        savedTask.setId(1L);
+        savedTask.setPlace("お風呂");
+        savedTask.setTarget("浴槽");
+        savedTask.setIntervalDays(7);
+        savedTask.setMethod("洗剤で洗う");
+        savedTask.setNextDueDate(LocalDate.now());
+
+        // repository.save()が呼ばれたら、準備したsavedTaskを返せと命令
+        when(taskRepository.save(any(Task.class))).thenReturn(savedTask);
+
+        // 実際にサービス層のメソッドを呼び出す
+        TaskResponse response = taskService.createTask(request);
+
+        // 期待した通りの結果が返ってきているかチェック（アサーション）
+        assertAll(
+            () -> assertEquals(1L, response.getId()),
+            () -> assertEquals("お風呂", response.getPlace()),
+            () -> assertEquals("浴槽", response.getTarget()),
+            () -> assertEquals(7, response.getIntervalDays()),
+            () -> assertEquals("洗剤で洗う", response.getMethod()),
+            () -> assertNotNull(response.getNextDueDate())
+        );
+
+        // リポジトリのsaveメソッドが本当に1回だけ呼ばれたか確認
+        verify(taskRepository, times(1)).save(any(Task.class));
+    }
+}

--- a/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
+++ b/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
@@ -3,6 +3,7 @@ package com.example.cleaning_notification_app.service;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.example.cleaning_notification_app.entity.Task;
+import com.example.cleaning_notification_app.exception.ResourceNotFoundException;
 import com.example.cleaning_notification_app.repository.TaskRepository;
 import com.example.cleaning_notification_app.request.TaskRequest;
 import com.example.cleaning_notification_app.response.TaskResponse;
@@ -97,7 +99,7 @@ public class TaskServiceImplTest {
     @Test
     @DisplayName("掃除タスクを更新できること")
     void updateTask_Success() {
-        Long taskId = 1l;
+        Long taskId = 1L;
 
         Task existingTask = new Task();
         existingTask.setId(taskId);
@@ -153,5 +155,36 @@ public class TaskServiceImplTest {
 
         verify(taskRepository, times(1)).findById(taskId);
         verify(taskRepository, times(1)).delete(existingTask);
+    }
+
+    @Test
+    @DisplayName("存在しないIDのタスクを更新しようとした場合、例外が発生すること")
+    void updateTask_NotFound() {
+        Long nonExistentId = 999L;
+        TaskRequest request = new TaskRequest("キッチン", "換気扇", 30, "重曹で洗う");
+
+        when(taskRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            taskService.updateTask(request, nonExistentId);
+        });
+
+        verify(taskRepository, times(1)).findById(nonExistentId);
+        verify(taskRepository, times(0)).save(any(Task.class));
+    }
+
+    @Test
+    @DisplayName("存在しないIDのタスクを削除しようとした場合、例外が発生すること")
+    void deleteTask_NotFound() {
+        Long nonExistentId = 999L;
+        
+        when(taskRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            taskService.deleteTask(nonExistentId);
+        });
+
+        verify(taskRepository, times(1)).findById(nonExistentId);
+        verify(taskRepository, times(0)).delete(any(Task.class));
     }
 }

--- a/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
+++ b/backend/src/test/java/com/example/cleaning_notification_app/service/TaskServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,7 +37,7 @@ public class TaskServiceImplTest {
     private TaskServiceImpl taskService;
 
     @Test
-    @DisplayName("タスク一覧を全権取得できること")
+    @DisplayName("タスク一覧を全件取得できること")
     void getAllTasks_Success() {
         Task task1 = new Task();
         task1.setPlace("場所1");
@@ -59,6 +60,8 @@ public class TaskServiceImplTest {
             () -> assertEquals("場所1", responses.get(0).getPlace()),
             () -> assertEquals("場所2", responses.get(1).getPlace())
         );
+
+        verify(taskRepository, times(1)).findAll();
     }
 
     @Test
@@ -170,7 +173,7 @@ public class TaskServiceImplTest {
         });
 
         verify(taskRepository, times(1)).findById(nonExistentId);
-        verify(taskRepository, times(0)).save(any(Task.class));
+        verify(taskRepository, never()).save(any(Task.class));
     }
 
     @Test
@@ -185,6 +188,6 @@ public class TaskServiceImplTest {
         });
 
         verify(taskRepository, times(1)).findById(nonExistentId);
-        verify(taskRepository, times(0)).delete(any(Task.class));
+        verify(taskRepository, never()).delete(any(Task.class));
     }
 }


### PR DESCRIPTION
掃除タスクの一覧取得、新規作成、更新、削除を実装しました。
service層、controller層、repository層（以前に作成ずみ）に分けて実装しました。
TaskRequest、TaskResponseを実装し、バリデーションも行えるようにしました。

Closes #5